### PR TITLE
Add label and tooltip for unlock date and show unlock date when locked

### DIFF
--- a/server/public/encrypt.html
+++ b/server/public/encrypt.html
@@ -24,9 +24,10 @@
   h1{margin:0 0 6px 0; font-size:22px}
   p.desc{margin:0 0 14px 0; color:var(--muted)}
   label{display:block; font-weight:600; margin:12px 0 6px}
-  input, textarea{
+  input:not([type="checkbox"]), textarea{
     width:100%; padding:12px; border-radius:12px; border:1px solid var(--border); background:#fff; font-size:15px;
   }
+  input[type="checkbox"]{ margin-right:6px; }
   textarea{min-height:110px; resize:vertical}
   .row{display:grid; grid-template-columns:1fr 1fr; gap:12px}
   @media (max-width:720px){ .row{grid-template-columns:1fr} }
@@ -62,7 +63,7 @@
 
       <div class="row">
         <div>
-          <label><input id="useDate" type="checkbox" /> Erişim tarihi</label>
+          <label title="Bu seçeneği işaretlersen, kayıt seçtiğin tarihe kadar kilitli kalır."><input id="useDate" type="checkbox" /> Erişim tarihini kullan</label>
           <input id="unlockDate" type="date" disabled />
         </div>
         <div>

--- a/server/public/retrieve.html
+++ b/server/public/retrieve.html
@@ -95,7 +95,12 @@
       try { j = JSON.parse(text) } catch(_) { /* html vs dönerse */ }
 
       if(!res.ok){
-        show(out, `<span class="err">Hata:</span> ${j.error || ('HTTP '+res.status)}`);
+        const msg = j.error || ('HTTP '+res.status);
+        if(res.status === 403){
+          show(out, msg);
+        } else {
+          show(out, `<span class="err">Hata:</span> ${msg}`);
+        }
         return;
       }
       show(out, `<div><b>Başlık:</b> ${j.title || '-'}</div>

--- a/server/server.js
+++ b/server/server.js
@@ -136,7 +136,7 @@ app.post('/api/get/:id', async (req, res) => {
       const now = new Date();
       const rd = new Date(row.unlockDate + 'T00:00:00');
       if (isNaN(rd.getTime())) return res.status(500).json({ error: 'Kayıtlı unlockDate geçersiz.' });
-      if (now < rd) return res.status(403).json({ error: 'Henüz erişim tarihi gelmedi' });
+        if (now < rd) return res.status(403).json({ error: `Şifre ${row.unlockDate} tarihinde çözülebilir` });
     }
 
     // 1) Passphrase'ten key türet → dek_pw'yi çöz → dek_kms elde et


### PR DESCRIPTION
## Summary
- Label the unlock date checkbox, add hover help, and fix checkbox styling
- Return the unlock date in 403 responses when access is attempted early
- Show server-provided message on the retrieve page for early access attempts

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_689c6516aac08331b76d6e01a9c268a0