### PR TITLE
Add master and view password support with owner updates

### DIFF
--- a/server/public/encrypt.html
+++ b/server/public/encrypt.html
@@ -95,6 +95,8 @@
 
   const useDateEl = document.getElementById('useDate');
   const unlockDateEl = document.getElementById('unlockDate');
+  const today = new Date().toISOString().split('T')[0];
+  unlockDateEl.min = today;
   useDateEl.addEventListener('change', () => {
     unlockDateEl.disabled = !useDateEl.checked;
     if(!useDateEl.checked) unlockDateEl.value = '';

--- a/server/public/encrypt.html
+++ b/server/public/encrypt.html
@@ -72,12 +72,15 @@
         </div>
       </div>
 
-      <label>Parola (boş bırakırsan otomatik üreteceğiz)</label>
-      <input id="passphrase" placeholder="Kendi parolan (önerilir)" />
+      <label>Master Parola (boş bırakırsan otomatik üreteceğiz)</label>
+      <input id="masterPass" placeholder="Master parola" />
+
+      <label>Görüntüleme Parolası (boş bırakırsan otomatik üreteceğiz)</label>
+      <input id="viewPass" placeholder="Görüntüleme parolası" />
 
       <div class="actions">
         <button id="saveBtn" class="btn">Kaydet</button>
-        <span class="muted">Kaydettikten sonra <b>ID</b> ve (gerekirse) <b>parola</b> görünecek — saklamayı unutma.</span>
+        <span class="muted">Kaydettikten sonra <b>ID</b> ve (gerekirse) <b>parolalar</b> görünecek — saklamayı unutma.</span>
       </div>
 
       <div id="result" class="out"></div>
@@ -103,19 +106,21 @@
     const useDate = useDateEl.checked;
     const unlockDate = useDate ? unlockDateEl.value : null;
     const email = document.getElementById('email').value || '';
-    let passphrase = document.getElementById('passphrase').value || '';
+    let masterPass = document.getElementById('masterPass').value || '';
+    let viewPass = document.getElementById('viewPass').value || '';
 
     const out = document.getElementById('result'); out.style.display='none'; out.innerHTML='';
 
     if(!secret.trim()) return alert('Gizli metin gerekli');
     if(useDate && !unlockDate) return alert('Erişim tarihi gerekli');
     if(!email) return alert('E-posta gerekli');
-    if(!passphrase) passphrase = genPassword();
+    if(!masterPass) masterPass = genPassword();
+    if(!viewPass) viewPass = genPassword();
 
     try{
       const res = await fetch(API_BASE + '/api/store', {
         method:'POST', headers:{'Content-Type':'application/json'},
-        body: JSON.stringify({ title, secret, unlockDate: useDate ? unlockDate : null, email, passphrase })
+        body: JSON.stringify({ title, secret, unlockDate: useDate ? unlockDate : null, email, masterPass, viewPass })
       });
       const j = await res.json();
       if(!res.ok) throw new Error(j.error || 'Kayıt başarısız');
@@ -123,7 +128,8 @@
       out.style.display='block';
       out.innerHTML =
         `<div><b>ID:</b> ${j.id}</div>
-         <div><b>Parola:</b> ${j.passphrase}</div>
+         <div><b>Master Parola:</b> ${j.masterPass}</div>
+         <div><b>Görüntüleme Parolası:</b> ${j.viewPass}</div>
          <div class="muted">Bu bilgileri güvenle sakla. Geri almak için <b>retrieve.html</b> sayfasında kullanacaksın.</div>`;
       document.getElementById('secret').value='';
     }catch(e){

--- a/server/public/retrieve.html
+++ b/server/public/retrieve.html
@@ -103,9 +103,40 @@
         }
         return;
       }
-      show(out, `<div><b>Başlık:</b> ${j.title || '-'}</div>
+
+      if(j.owner){
+        let html = '';
+        if(j.secret){
+          html += `<div><b>Başlık:</b> ${j.title || '-'}</div>`;
+          html += `<div style="margin-top:8px"><b>Gizli metin:</b></div>`;
+          html += `<pre style="white-space:pre-wrap;margin:6px 0 0 0">${j.secret}</pre>`;
+        }else if(j.message){
+          html += j.message;
+        }
+        html += `<div style="margin-top:10px"><label>E-posta</label><input id="updEmail" value="${j.email || ''}" /></div>`;
+        html += `<div style="margin-top:10px"><label>Erişim Tarihi</label><input id="updDate" type="date" value="${j.unlockDate || ''}" /></div>`;
+        html += `<button id="updBtn" class="btn" style="margin-top:10px">Güncelle</button>`;
+        show(out, html);
+        document.getElementById('updBtn').addEventListener('click', async ()=>{
+          const email = document.getElementById('updEmail').value || '';
+          const unlockDate = document.getElementById('updDate').value || '';
+          try{
+            const res2 = await fetch(API_BASE + '/api/update/' + encodeURIComponent(id), {
+              method:'POST', headers:{'Content-Type':'application/json'},
+              body: JSON.stringify({ passphrase, email, unlockDate })
+            });
+            const j2 = await res2.json();
+            if(!res2.ok) throw new Error(j2.error || 'Güncelleme başarısız');
+            show(out, 'Güncellendi');
+          }catch(e){
+            show(out, `<span class="err">Hata:</span> ${e.message}`);
+          }
+        });
+      } else {
+        show(out, `<div><b>Başlık:</b> ${j.title || '-'}</div>
                  <div style="margin-top:8px"><b>Gizli metin:</b></div>
                  <pre style="white-space:pre-wrap;margin:6px 0 0 0">${j.secret}</pre>`);
+      }
     }catch(e){
       console.error('[retrieve] error', e);
       const out = document.getElementById('result');

--- a/server/public/retrieve.html
+++ b/server/public/retrieve.html
@@ -117,7 +117,9 @@
        html += `<div style="margin-top:10px"><label>Erişim Tarihi</label><input id="updDate" type="date" value="${j.unlockDate || ''}" /></div>`;
        html += `<button id="updBtn" class="btn" style="margin-top:10px">Güncelle</button>`;
        show(out, html);
-        document.getElementById('updDate').min = new Date().toISOString().split('T')[0];
+        const todayStr = new Date().toISOString().split('T')[0];
+        const minDate = j.unlockDate && j.unlockDate > todayStr ? j.unlockDate : todayStr;
+        document.getElementById('updDate').min = minDate;
         document.getElementById('updBtn').addEventListener('click', async ()=>{
           const email = document.getElementById('updEmail').value || '';
           const unlockDate = document.getElementById('updDate').value || '';

--- a/server/public/retrieve.html
+++ b/server/public/retrieve.html
@@ -114,9 +114,10 @@
           html += j.message;
         }
         html += `<div style="margin-top:10px"><label>E-posta</label><input id="updEmail" value="${j.email || ''}" /></div>`;
-        html += `<div style="margin-top:10px"><label>Erişim Tarihi</label><input id="updDate" type="date" value="${j.unlockDate || ''}" /></div>`;
-        html += `<button id="updBtn" class="btn" style="margin-top:10px">Güncelle</button>`;
-        show(out, html);
+       html += `<div style="margin-top:10px"><label>Erişim Tarihi</label><input id="updDate" type="date" value="${j.unlockDate || ''}" /></div>`;
+       html += `<button id="updBtn" class="btn" style="margin-top:10px">Güncelle</button>`;
+       show(out, html);
+        document.getElementById('updDate').min = new Date().toISOString().split('T')[0];
         document.getElementById('updBtn').addEventListener('click', async ()=>{
           const email = document.getElementById('updEmail').value || '';
           const unlockDate = document.getElementById('updDate').value || '';

--- a/server/server.js
+++ b/server/server.js
@@ -101,7 +101,7 @@ app.post('/api/store', async (req, res) => {
       today.setHours(0, 0, 0, 0);
       const rd = new Date(unlockDate + 'T00:00:00');
       if (isNaN(rd.getTime()) || rd < today) {
-        return res.status(400).json({ error: 'unlockDate bugünden önce olamaz' });
+        return res.status(400).json({ error: 'Seçilen tarih geçmişte olmamalı' });
       }
     }
 
@@ -225,7 +225,7 @@ app.post('/api/update/:id', async (req, res) => {
       today.setHours(0, 0, 0, 0);
       const rd = new Date(unlockDate + 'T00:00:00');
       if (isNaN(rd.getTime()) || rd < today) {
-        return res.status(400).json({ error: 'unlockDate bugünden önce olamaz' });
+        return res.status(400).json({ error: 'Seçilen tarih geçmişte olmamalı' });
       }
       upd.unlockDate = unlockDate;
     }

--- a/server/server.js
+++ b/server/server.js
@@ -96,6 +96,15 @@ app.post('/api/store', async (req, res) => {
       return res.status(500).json({ error: 'Sunucu yapılandırması eksik (KMS anahtarı tanımlı değil).' });
     }
 
+    if (unlockDate) {
+      const today = new Date();
+      today.setHours(0, 0, 0, 0);
+      const rd = new Date(unlockDate + 'T00:00:00');
+      if (isNaN(rd.getTime()) || rd < today) {
+        return res.status(400).json({ error: 'unlockDate bugünden önce olamaz' });
+      }
+    }
+
     // 1) Veriyi yerel DEK ile şifrele
     const { key: DEK, iv, ct, tag } = aeadEncrypt(secret);
 
@@ -212,10 +221,11 @@ app.post('/api/update/:id', async (req, res) => {
 
     const upd = {};
     if (unlockDate) {
-      const now = new Date();
+      const today = new Date();
+      today.setHours(0, 0, 0, 0);
       const rd = new Date(unlockDate + 'T00:00:00');
-      if (isNaN(rd.getTime()) || rd <= now) {
-        return res.status(400).json({ error: 'unlockDate gelecekte olmalı' });
+      if (isNaN(rd.getTime()) || rd < today) {
+        return res.status(400).json({ error: 'unlockDate bugünden önce olamaz' });
       }
       upd.unlockDate = unlockDate;
     }

--- a/server/server.js
+++ b/server/server.js
@@ -227,6 +227,12 @@ app.post('/api/update/:id', async (req, res) => {
       if (isNaN(rd.getTime()) || rd < today) {
         return res.status(400).json({ error: 'Seçilen tarih geçmişte olmamalı' });
       }
+      if (row.unlockDate) {
+        const curr = new Date(row.unlockDate + 'T00:00:00');
+        if (rd < curr) {
+          return res.status(400).json({ error: 'Yeni tarih mevcut tarihten önce olamaz' });
+        }
+      }
       upd.unlockDate = unlockDate;
     }
     if (email) {

--- a/server/server.js
+++ b/server/server.js
@@ -79,6 +79,13 @@ async function unwrapDek(block, passphrase) {
   return dek_kms;
 }
 
+function formatDateTR(dateStr) {
+  const parts = (dateStr || '').split('-');
+  if (parts.length !== 3) return dateStr;
+  const [y, m, d] = parts;
+  return `${d}.${m}.${y}`;
+}
+
 // ── Sağlık kontrolü ───────────────────────────────────────────────────────────
 app.get('/healthz', (req, res) => {
   const ok = !!(PROJECT_ID && KEYRING && KEYNAME && kmsKeyPath);
@@ -175,9 +182,9 @@ app.post('/api/get/:id', async (req, res) => {
       if (isNaN(rd.getTime())) return res.status(500).json({ error: 'Kayıtlı unlockDate geçersiz.' });
       if (now < rd) {
         if (owner) {
-          return res.json({ id, unlockDate: row.unlockDate, email: row.email, owner: true, message: `Şifre ${row.unlockDate} tarihinde çözülebilir` });
+          return res.json({ id, unlockDate: row.unlockDate, email: row.email, owner: true, message: `Şifre ${formatDateTR(row.unlockDate)} tarihinde çözülebilir` });
         }
-        return res.status(403).json({ error: `Şifre ${row.unlockDate} tarihinde çözülebilir` });
+        return res.status(403).json({ error: `Şifre ${formatDateTR(row.unlockDate)} tarihinde çözülebilir` });
       }
     }
 


### PR DESCRIPTION
## Summary
- Support separate master and view passwords when storing secrets and encrypt data accordingly
- Let creators view or update email and unlock date before release, restricting regular viewers
- Add API endpoint for updating secret metadata and adjust frontend forms to handle new passwords

## Testing
- `node --check server/server.js`
- `npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_689c6de6020c8331be0c1a4fce24d0cc