### PR TITLE
Add trust page with GitHub link

### DIFF
--- a/server/public/encrypt.html
+++ b/server/public/encrypt.html
@@ -81,6 +81,7 @@
     <nav>
       <a href="./index.html">Ana Sayfa</a>
       <a href="./use-cases.html">Kullanım Senaryoları</a>
+      <a href="./neden-guvenebilirsiniz.html">Neden Güvenebilirsiniz</a>
       <a href="./encrypt.html">Kaydet</a>
       <a href="./retrieve.html">Geri Al</a>
     </nav>
@@ -121,7 +122,7 @@
     </div>
   </div>
 </main>
-<footer>© 2025 Gelecek Kasası — Verileriniz AES-256-GCM ve Google KMS ile korunur. İletişim: info@example.com</footer>
+<footer>© 2025 Gelecek Kasası — Verileriniz AES-256-GCM ve Google KMS ile korunur. İletişim: info@example.com — <a href="https://github.com/cebiromerfaruk/lockeduntil" style="color:inherit;">GitHub</a></footer>
 <script>
   const API_BASE = ''; // aynı origin
   function genPassword(){ const a=new Uint8Array(16); crypto.getRandomValues(a); return btoa(String.fromCharCode(...a)); }

--- a/server/public/index.html
+++ b/server/public/index.html
@@ -81,6 +81,7 @@
     <nav>
       <a href="./index.html">Ana Sayfa</a>
       <a href="./use-cases.html">Kullanım Senaryoları</a>
+      <a href="./neden-guvenebilirsiniz.html">Neden Güvenebilirsiniz</a>
       <a href="./encrypt.html">Kaydet</a>
       <a href="./retrieve.html">Geri Al</a>
     </nav>
@@ -109,6 +110,6 @@
     </div>
   </div>
 </main>
-<footer>© 2025 Gelecek Kasası — Verileriniz AES-256-GCM ve Google KMS ile korunur. İletişim: info@example.com</footer>
+<footer>© 2025 Gelecek Kasası — Verileriniz AES-256-GCM ve Google KMS ile korunur. İletişim: info@example.com — <a href="https://github.com/cebiromerfaruk/lockeduntil" style="color:inherit;">GitHub</a></footer>
 </body>
 </html>

--- a/server/public/neden-guvenebilirsiniz.html
+++ b/server/public/neden-guvenebilirsiniz.html
@@ -1,0 +1,89 @@
+<!doctype html>
+<html lang="tr">
+<head>
+<meta charset="utf-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1" />
+<title>Neden Güvenebilirsiniz | Zaman Kilitli Güvenli Paylaşım</title>
+<meta name="description" content="Kaynak kodumuz herkese açık ve şifreler sunucuda tutulmaz. Neden güvenebileceğinizi öğrenin." />
+<link rel="canonical" href="https://timelockedvault.example/neden-guvenebilirsiniz.html" />
+<meta property="og:title" content="Neden Güvenebilirsiniz - Gelecek Kasası" />
+<meta property="og:description" content="Kaynak kodumuz herkese açık ve şifreler sunucuda tutulmaz." />
+<meta property="og:type" content="website" />
+<meta property="og:url" content="https://timelockedvault.example/neden-guvenebilirsiniz.html" />
+<meta property="og:site_name" content="Gelecek Kasası" />
+<meta property="og:image" content="https://timelockedvault.example/og-image.png" />
+<meta name="twitter:card" content="summary_large_image" />
+<meta name="twitter:title" content="Neden Güvenebilirsiniz - Gelecek Kasası" />
+<meta name="twitter:description" content="Kaynak kodumuz herkese açık ve şifreler sunucuda tutulmaz." />
+<meta name="twitter:image" content="https://timelockedvault.example/og-image.png" />
+<style>
+  :root{--bg1:#0f172a;--bg2:#0ea5a9;--card:#ffffff;--ink:#0f172a;--muted:#6b7280;--pri:#0ea5a9;--pri2:#10b981;--border:#e6e9ee;}
+  *{box-sizing:border-box;margin:0;padding:0}
+  body{margin:0;font-family:system-ui,-apple-system,Segoe UI,Roboto,Arial,sans-serif;color:var(--ink);background:radial-gradient(1200px 800px at 80% -10%,rgba(255,255,255,0.08),transparent 60%),linear-gradient(135deg,var(--bg1),var(--bg2));min-height:100vh;display:flex;flex-direction:column;}
+  header{background:rgba(255,255,255,.08);backdrop-filter:blur(4px);}
+  .nav{max-width:960px;margin:0 auto;display:flex;align-items:center;justify-content:space-between;padding:12px 20px;}
+  .nav a{color:#fff;text-decoration:none;margin-right:16px;}
+  .nav a:last-child{margin-right:0;}
+    .nav .logo{margin-right:0;}
+  .nav .logo img{height:28px;}
+  @media(max-width:600px){
+    .nav{flex-direction:column;align-items:flex-start;}
+    .nav nav{margin-top:8px;display:flex;flex-wrap:wrap;}
+    .nav a{margin:4px 12px 0 0;}
+    .nav a:last-child{margin-right:0;}
+  }
+  main{flex:1;display:flex;justify-content:center;padding:40px 20px;}
+  .wrap{width:100%;max-width:880px;}
+  h1{color:#fff;font-size:32px;margin-bottom:24px;text-align:center;}
+  section{background:var(--card);border:1px solid var(--border);border-radius:16px;padding:24px;line-height:1.6;}
+  section a{color:var(--pri);text-decoration:none;font-weight:600;}
+  footer{text-align:center;font-size:13px;color:rgba(255,255,255,.65);padding:20px;}
+</style>
+<script type="application/ld+json">
+{
+ "@context":"https://schema.org",
+ "@type":"Organization",
+ "name":"Gelecek Kasası",
+ "url":"https://timelockedvault.example/",
+ "contactPoint":[{"@type":"ContactPoint","email":"info@timelockedvault.example","contactType":"customer support"}]
+}
+</script>
+<script type="application/ld+json">
+{
+ "@context":"https://schema.org",
+ "@type":"WebSite",
+ "url":"https://timelockedvault.example/",
+ "potentialAction":{
+    "@type":"SearchAction",
+    "target":"https://timelockedvault.example/search?q={search_term_string}",
+    "query-input":"required name=search_term_string"
+ }
+}
+</script>
+</head>
+<body>
+<header>
+  <div class="nav">
+    <a class="logo" href="./index.html"><img src="./logo.svg" alt="Gelecek Kasası logo"></a>
+    <nav>
+      <a href="./index.html">Ana Sayfa</a>
+      <a href="./use-cases.html">Kullanım Senaryoları</a>
+      <a href="./neden-guvenebilirsiniz.html">Neden Güvenebilirsiniz</a>
+      <a href="./encrypt.html">Kaydet</a>
+      <a href="./retrieve.html">Geri Al</a>
+    </nav>
+  </div>
+</header>
+<main>
+  <div class="wrap">
+    <h1>Neden Güvenebilirsiniz?</h1>
+    <section>
+      <p>Bu projenin tüm kaynak kodu herkese açıktır. Dilediğiniz zaman incelemek için <a href="https://github.com/cebiromerfaruk/lockeduntil" target="_blank">GitHub deposunu</a> ziyaret edebilirsiniz.</p>
+      <p>Şifreler ve ID'ler hiçbir şekilde sunucuda kaydedilmez. Veriler tarayıcınızda şifrelenir ve sunucuya yalnızca şifreli hâli gönderilir.</p>
+      <p>Böylece kimlik bilgileriniz ve parolalarınız bizim sistemlerimizde tutulmadan güvende kalır.</p>
+    </section>
+  </div>
+</main>
+<footer>© 2025 Gelecek Kasası — Verileriniz AES-256-GCM ve Google KMS ile korunur. İletişim: info@example.com — <a href="https://github.com/cebiromerfaruk/lockeduntil" style="color:inherit;">GitHub</a></footer>
+</body>
+</html>

--- a/server/public/retrieve.html
+++ b/server/public/retrieve.html
@@ -76,6 +76,7 @@
     <nav>
       <a href="./index.html">Ana Sayfa</a>
       <a href="./use-cases.html">Kullanım Senaryoları</a>
+      <a href="./neden-guvenebilirsiniz.html">Neden Güvenebilirsiniz</a>
       <a href="./encrypt.html">Kaydet</a>
       <a href="./retrieve.html">Geri Al</a>
     </nav>
@@ -100,7 +101,7 @@
     </div>
   </div>
 </main>
-<footer>© 2025 Gelecek Kasası — Verileriniz AES-256-GCM ve Google KMS ile korunur. İletişim: info@example.com</footer>
+<footer>© 2025 Gelecek Kasası — Verileriniz AES-256-GCM ve Google KMS ile korunur. İletişim: info@example.com — <a href="https://github.com/cebiromerfaruk/lockeduntil" style="color:inherit;">GitHub</a></footer>
 <script>
   const API_BASE = ''; // aynı origin
   function show(outEl, html){ outEl.style.display='block'; outEl.innerHTML = html; }

--- a/server/public/sitemap.xml
+++ b/server/public/sitemap.xml
@@ -2,6 +2,7 @@
 <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
   <url><loc>https://timelockedvault.example/</loc></url>
   <url><loc>https://timelockedvault.example/use-cases.html</loc></url>
+  <url><loc>https://timelockedvault.example/neden-guvenebilirsiniz.html</loc></url>
   <url><loc>https://timelockedvault.example/encrypt.html</loc></url>
   <url><loc>https://timelockedvault.example/retrieve.html</loc></url>
 </urlset>

--- a/server/public/use-cases.html
+++ b/server/public/use-cases.html
@@ -106,6 +106,7 @@
     <nav>
       <a href="./index.html">Ana Sayfa</a>
       <a href="./use-cases.html">Kullanım Senaryoları</a>
+      <a href="./neden-guvenebilirsiniz.html">Neden Güvenebilirsiniz</a>
       <a href="./encrypt.html">Kaydet</a>
       <a href="./retrieve.html">Geri Al</a>
     </nav>
@@ -150,6 +151,6 @@
     </div>
   </div>
 </main>
-<footer>© 2025 Gelecek Kasası — Verileriniz AES-256-GCM ve Google KMS ile korunur. İletişim: info@example.com</footer>
+<footer>© 2025 Gelecek Kasası — Verileriniz AES-256-GCM ve Google KMS ile korunur. İletişim: info@example.com — <a href="https://github.com/cebiromerfaruk/lockeduntil" style="color:inherit;">GitHub</a></footer>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- add **Neden Güvenebilirsiniz** page explaining that the project is open-source and no passwords or IDs are stored
- link the new page from navigation and add GitHub repo link in footers
- update sitemap to list the trust page

## Testing
- `npm test` *(fails: Missing script: "test")*


------
https://chatgpt.com/codex/tasks/task_e_689dc75f17a48331b3d7ee582df2f0f6