### PR TITLE
Add basic Android app with bilingual support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -137,3 +137,7 @@ dist
 # Vite logs files
 vite.config.js.timestamp-*
 vite.config.ts.timestamp-*
+
+# Android build directories
+android/.gradle/
+android/app/build/

--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -1,0 +1,30 @@
+plugins {
+    id 'com.android.application'
+    id 'org.jetbrains.kotlin.android'
+}
+
+android {
+    namespace 'com.example.lockeduntil'
+    compileSdk 34
+
+    defaultConfig {
+        applicationId "com.example.lockeduntil"
+        minSdk 24
+        targetSdk 34
+        versionCode 1
+        versionName "1.0"
+    }
+    buildTypes {
+        release {
+            minifyEnabled false
+            proguardFiles getDefaultProguardFile('proguard-android-optimize.txt'), 'proguard-rules.pro'
+        }
+    }
+}
+
+dependencies {
+    implementation 'androidx.appcompat:appcompat:1.6.1'
+    implementation 'com.google.android.material:material:1.11.0'
+    implementation 'org.jetbrains.kotlinx:kotlinx-coroutines-android:1.7.3'
+    implementation 'com.squareup.okhttp3:okhttp:4.12.0'
+}

--- a/android/app/proguard-rules.pro
+++ b/android/app/proguard-rules.pro
@@ -1,0 +1,1 @@
+# Proguard rules (empty)

--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -1,0 +1,19 @@
+<manifest xmlns:android="http://schemas.android.com/apk/res/android"
+    package="com.example.lockeduntil">
+
+    <uses-permission android:name="android.permission.INTERNET" />
+
+    <application
+        android:allowBackup="true"
+        android:label="@string/app_name"
+        android:supportsRtl="true"
+        android:theme="@style/Theme.LockedUntil">
+        <activity android:name=".MainActivity">
+            <intent-filter>
+                <action android:name="android.intent.action.MAIN" />
+                <category android:name="android.intent.category.LAUNCHER" />
+            </intent-filter>
+        </activity>
+    </application>
+
+</manifest>

--- a/android/app/src/main/java/com/example/lockeduntil/MainActivity.kt
+++ b/android/app/src/main/java/com/example/lockeduntil/MainActivity.kt
@@ -1,0 +1,84 @@
+package com.example.lockeduntil
+
+import android.os.Bundle
+import android.widget.Button
+import android.widget.EditText
+import android.widget.TextView
+import androidx.appcompat.app.AppCompatActivity
+import okhttp3.*
+import okhttp3.MediaType.Companion.toMediaType
+import okhttp3.RequestBody.Companion.toRequestBody
+import org.json.JSONObject
+import java.io.IOException
+import java.util.Locale
+
+class MainActivity : AppCompatActivity() {
+    private val client = OkHttpClient()
+    private val baseUrl = "http://10.0.2.2:8080"
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        setContentView(R.layout.activity_main)
+
+        val lang = if (Locale.getDefault().language == "tr") "tr" else "en"
+
+        val secretInput = findViewById<EditText>(R.id.secretInput)
+        val emailInput = findViewById<EditText>(R.id.emailInput)
+        val masterPassInput = findViewById<EditText>(R.id.masterPassInput)
+        val viewPassInput = findViewById<EditText>(R.id.viewPassInput)
+        val dateInput = findViewById<EditText>(R.id.dateInput)
+        val storeButton = findViewById<Button>(R.id.storeButton)
+        val storeResult = findViewById<TextView>(R.id.storeResult)
+
+        val idInput = findViewById<EditText>(R.id.idInput)
+        val passInput = findViewById<EditText>(R.id.passInput)
+        val retrieveButton = findViewById<Button>(R.id.retrieveButton)
+        val retrieveResult = findViewById<TextView>(R.id.retrieveResult)
+
+        storeButton.setOnClickListener {
+            val json = JSONObject().apply {
+                put("secret", secretInput.text.toString())
+                put("email", emailInput.text.toString())
+                put("masterPass", masterPassInput.text.toString())
+                put("viewPass", viewPassInput.text.toString())
+                put("lang", lang)
+                val d = dateInput.text.toString()
+                if (d.isNotEmpty()) put("unlockDate", d)
+            }
+            val reqBody = json.toString().toRequestBody(JSON)
+            val request = Request.Builder().url("$baseUrl/api/store").post(reqBody).build()
+            client.newCall(request).enqueue(object : Callback {
+                override fun onFailure(call: Call, e: IOException) {
+                    runOnUiThread { storeResult.text = e.message }
+                }
+                override fun onResponse(call: Call, response: Response) {
+                    val body = response.body?.string() ?: ""
+                    runOnUiThread { storeResult.text = body }
+                }
+            })
+        }
+
+        retrieveButton.setOnClickListener {
+            val json = JSONObject().apply {
+                put("passphrase", passInput.text.toString())
+                put("lang", lang)
+            }
+            val id = idInput.text.toString()
+            val reqBody = json.toString().toRequestBody(JSON)
+            val request = Request.Builder().url("$baseUrl/api/get/$id").post(reqBody).build()
+            client.newCall(request).enqueue(object : Callback {
+                override fun onFailure(call: Call, e: IOException) {
+                    runOnUiThread { retrieveResult.text = e.message }
+                }
+                override fun onResponse(call: Call, response: Response) {
+                    val body = response.body?.string() ?: ""
+                    runOnUiThread { retrieveResult.text = body }
+                }
+            })
+        }
+    }
+
+    companion object {
+        private val JSON = "application/json; charset=utf-8".toMediaType()
+    }
+}

--- a/android/app/src/main/res/layout/activity_main.xml
+++ b/android/app/src/main/res/layout/activity_main.xml
@@ -1,0 +1,98 @@
+<?xml version="1.0" encoding="utf-8"?>
+<ScrollView xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent">
+
+    <LinearLayout
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:orientation="vertical"
+        android:padding="16dp">
+
+        <TextView
+            android:id="@+id/storeTitle"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:text="@string/store_title"
+            android:textStyle="bold" />
+
+        <EditText
+            android:id="@+id/secretInput"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:hint="@string/hint_secret"/>
+
+        <EditText
+            android:id="@+id/emailInput"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:hint="@string/hint_email"/>
+
+        <EditText
+            android:id="@+id/masterPassInput"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:hint="@string/hint_master"/>
+
+        <EditText
+            android:id="@+id/viewPassInput"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:hint="@string/hint_view"/>
+
+        <EditText
+            android:id="@+id/dateInput"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:hint="@string/hint_date"/>
+
+        <Button
+            android:id="@+id/storeButton"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:text="@string/store_button"/>
+
+        <TextView
+            android:id="@+id/storeResult"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"/>
+
+        <View
+            android:layout_width="match_parent"
+            android:layout_height="1dp"
+            android:background="#CCCCCC"
+            android:layout_marginTop="16dp"
+            android:layout_marginBottom="16dp"/>
+
+        <TextView
+            android:id="@+id/retrieveTitle"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:text="@string/retrieve_title"
+            android:textStyle="bold" />
+
+        <EditText
+            android:id="@+id/idInput"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:hint="@string/hint_id"/>
+
+        <EditText
+            android:id="@+id/passInput"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:hint="@string/hint_password"/>
+
+        <Button
+            android:id="@+id/retrieveButton"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:text="@string/retrieve_button"/>
+
+        <TextView
+            android:id="@+id/retrieveResult"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"/>
+
+    </LinearLayout>
+</ScrollView>

--- a/android/app/src/main/res/values-night/themes.xml
+++ b/android/app/src/main/res/values-night/themes.xml
@@ -1,0 +1,5 @@
+<resources xmlns:tools="http://schemas.android.com/tools">
+    <style name="Theme.LockedUntil" parent="Theme.MaterialComponents.DayNight.DarkActionBar">
+        <!-- Night theme -->
+    </style>
+</resources>

--- a/android/app/src/main/res/values-tr/strings.xml
+++ b/android/app/src/main/res/values-tr/strings.xml
@@ -1,0 +1,14 @@
+<resources>
+    <string name="app_name">KilidiAçılanaKadar</string>
+    <string name="store_title">Gizli Metni Kaydet</string>
+    <string name="hint_secret">Gizli metin</string>
+    <string name="hint_email">E-posta</string>
+    <string name="hint_master">Ana parola</string>
+    <string name="hint_view">Görüntüleme parolası</string>
+    <string name="hint_date">Açılma tarihi (YYYY-AA-GG)</string>
+    <string name="store_button">Kaydet</string>
+    <string name="retrieve_title">Gizli Metni Çöz</string>
+    <string name="hint_id">ID</string>
+    <string name="hint_password">Parola</string>
+    <string name="retrieve_button">Çöz</string>
+</resources>

--- a/android/app/src/main/res/values/strings.xml
+++ b/android/app/src/main/res/values/strings.xml
@@ -1,0 +1,14 @@
+<resources>
+    <string name="app_name">LockedUntil</string>
+    <string name="store_title">Store Secret</string>
+    <string name="hint_secret">Secret text</string>
+    <string name="hint_email">Email</string>
+    <string name="hint_master">Master password</string>
+    <string name="hint_view">View password</string>
+    <string name="hint_date">Unlock date (YYYY-MM-DD)</string>
+    <string name="store_button">Store</string>
+    <string name="retrieve_title">Retrieve Secret</string>
+    <string name="hint_id">ID</string>
+    <string name="hint_password">Password</string>
+    <string name="retrieve_button">Retrieve</string>
+</resources>

--- a/android/app/src/main/res/values/themes.xml
+++ b/android/app/src/main/res/values/themes.xml
@@ -1,0 +1,5 @@
+<resources xmlns:tools="http://schemas.android.com/tools">
+    <style name="Theme.LockedUntil" parent="Theme.MaterialComponents.DayNight.DarkActionBar">
+        <!-- Customize your theme here. -->
+    </style>
+</resources>

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -1,0 +1,21 @@
+buildscript {
+    repositories {
+        google()
+        mavenCentral()
+    }
+    dependencies {
+        classpath "com.android.tools.build:gradle:8.1.1"
+        classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:1.9.0"
+    }
+}
+
+allprojects {
+    repositories {
+        google()
+        mavenCentral()
+    }
+}
+
+task clean(type: Delete) {
+    delete rootProject.buildDir
+}

--- a/android/settings.gradle
+++ b/android/settings.gradle
@@ -1,0 +1,2 @@
+rootProject.name = "LockedUntil"
+include(":app")


### PR DESCRIPTION
## Summary
- add Android project providing secret storage and retrieval against existing server
- include English and Turkish localizations and basic UI
- ignore Android build outputs in git

## Testing
- `cd android && ./gradlew test` *(fails: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_689de286281883318a6dabd9cc749568