### PR TITLE
feat: split android app into colorful multi-screen flow

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -8,6 +8,10 @@
         android:supportsRtl="true"
         android:theme="@style/Theme.LockedUntil">
 
+        <activity android:name=".StoreActivity" />
+        <activity android:name=".RetrieveActivity" />
+        <activity android:name=".WhyTrustActivity" />
+        <activity android:name=".UseCasesActivity" />
         <activity
             android:name=".MainActivity"
             android:exported="true">   <!-- Android 12+ zorunlu -->

--- a/android/app/src/main/java/com/example/lockeduntil/MainActivity.kt
+++ b/android/app/src/main/java/com/example/lockeduntil/MainActivity.kt
@@ -1,91 +1,26 @@
 package com.lockeduntil.app
 
+import android.content.Intent
 import android.os.Bundle
 import android.widget.Button
-import android.widget.EditText
-import android.widget.TextView
 import androidx.appcompat.app.AppCompatActivity
 
-import java.util.Locale
-import org.json.JSONObject
-
-import okhttp3.OkHttpClient
-import okhttp3.Request
-import okhttp3.RequestBody
-import okhttp3.MediaType.Companion.toMediaType
-import okhttp3.RequestBody.Companion.toRequestBody
-import okhttp3.Call
-import okhttp3.Callback
-import okhttp3.Response
-import java.io.IOException
-
 class MainActivity : AppCompatActivity() {
-    private val client = OkHttpClient()
-    private val baseUrl = "http://10.0.2.2:8080"
-
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
-        setContentView(R.layout.activity_main)
+        setContentView(R.layout.activity_home)
 
-        val lang = if (Locale.getDefault().language == "tr") "tr" else "en"
-
-        val secretInput = findViewById<EditText>(R.id.secretInput)
-        val emailInput = findViewById<EditText>(R.id.emailInput)
-        val masterPassInput = findViewById<EditText>(R.id.masterPassInput)
-        val viewPassInput = findViewById<EditText>(R.id.viewPassInput)
-        val dateInput = findViewById<EditText>(R.id.dateInput)
-        val storeButton = findViewById<Button>(R.id.storeButton)
-        val storeResult = findViewById<TextView>(R.id.storeResult)
-
-        val idInput = findViewById<EditText>(R.id.idInput)
-        val passInput = findViewById<EditText>(R.id.passInput)
-        val retrieveButton = findViewById<Button>(R.id.retrieveButton)
-        val retrieveResult = findViewById<TextView>(R.id.retrieveResult)
-
-        storeButton.setOnClickListener {
-            val json = JSONObject().apply {
-                put("secret", secretInput.text.toString())
-                put("email", emailInput.text.toString())
-                put("masterPass", masterPassInput.text.toString())
-                put("viewPass", viewPassInput.text.toString())
-                put("lang", lang)
-                val d = dateInput.text.toString()
-                if (d.isNotEmpty()) put("unlockDate", d)
-            }
-            val reqBody = json.toString().toRequestBody(JSON)
-            val request = Request.Builder().url("$baseUrl/api/store").post(reqBody).build()
-            client.newCall(request).enqueue(object : Callback {
-                override fun onFailure(call: Call, e: IOException) {
-                    runOnUiThread { storeResult.text = e.message }
-                }
-                override fun onResponse(call: Call, response: Response) {
-                    val body = response.body?.string() ?: ""
-                    runOnUiThread { storeResult.text = body }
-                }
-            })
+        findViewById<Button>(R.id.btnStore).setOnClickListener {
+            startActivity(Intent(this, StoreActivity::class.java))
         }
-
-        retrieveButton.setOnClickListener {
-            val json = JSONObject().apply {
-                put("passphrase", passInput.text.toString())
-                put("lang", lang)
-            }
-            val id = idInput.text.toString()
-            val reqBody = json.toString().toRequestBody(JSON)
-            val request = Request.Builder().url("$baseUrl/api/get/$id").post(reqBody).build()
-            client.newCall(request).enqueue(object : Callback {
-                override fun onFailure(call: Call, e: IOException) {
-                    runOnUiThread { retrieveResult.text = e.message }
-                }
-                override fun onResponse(call: Call, response: Response) {
-                    val body = response.body?.string() ?: ""
-                    runOnUiThread { retrieveResult.text = body }
-                }
-            })
+        findViewById<Button>(R.id.btnRetrieve).setOnClickListener {
+            startActivity(Intent(this, RetrieveActivity::class.java))
         }
-    }
-
-    companion object {
-        private val JSON = "application/json; charset=utf-8".toMediaType()
+        findViewById<Button>(R.id.btnWhyTrust).setOnClickListener {
+            startActivity(Intent(this, WhyTrustActivity::class.java))
+        }
+        findViewById<Button>(R.id.btnUseCases).setOnClickListener {
+            startActivity(Intent(this, UseCasesActivity::class.java))
+        }
     }
 }

--- a/android/app/src/main/java/com/example/lockeduntil/RetrieveActivity.kt
+++ b/android/app/src/main/java/com/example/lockeduntil/RetrieveActivity.kt
@@ -1,0 +1,57 @@
+package com.lockeduntil.app
+
+import android.os.Bundle
+import android.widget.Button
+import android.widget.EditText
+import android.widget.TextView
+import androidx.appcompat.app.AppCompatActivity
+import java.util.Locale
+import org.json.JSONObject
+import okhttp3.OkHttpClient
+import okhttp3.Request
+import okhttp3.MediaType.Companion.toMediaType
+import okhttp3.RequestBody.Companion.toRequestBody
+import okhttp3.Call
+import okhttp3.Callback
+import okhttp3.Response
+import java.io.IOException
+
+class RetrieveActivity : AppCompatActivity() {
+    private val client = OkHttpClient()
+    private val baseUrl = "http://10.0.2.2:8080"
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        setContentView(R.layout.activity_retrieve)
+
+        val lang = if (Locale.getDefault().language == "tr") "tr" else "en"
+
+        val idInput = findViewById<EditText>(R.id.idInput)
+        val passInput = findViewById<EditText>(R.id.passInput)
+        val retrieveButton = findViewById<Button>(R.id.retrieveButton)
+        val retrieveResult = findViewById<TextView>(R.id.retrieveResult)
+
+        retrieveButton.setOnClickListener {
+            val json = JSONObject().apply {
+                put("passphrase", passInput.text.toString())
+                put("lang", lang)
+            }
+            val id = idInput.text.toString()
+            val reqBody = json.toString().toRequestBody(JSON)
+            val request = Request.Builder().url("$baseUrl/api/get/$id").post(reqBody).build()
+            client.newCall(request).enqueue(object : Callback {
+                override fun onFailure(call: Call, e: IOException) {
+                    runOnUiThread { retrieveResult.text = e.message }
+                }
+                override fun onResponse(call: Call, response: Response) {
+                    val body = response.body?.string() ?: ""
+                    runOnUiThread { retrieveResult.text = body }
+                }
+            })
+        }
+    }
+
+    companion object {
+        private val JSON = "application/json; charset=utf-8".toMediaType()
+    }
+}

--- a/android/app/src/main/java/com/example/lockeduntil/StoreActivity.kt
+++ b/android/app/src/main/java/com/example/lockeduntil/StoreActivity.kt
@@ -1,0 +1,67 @@
+package com.lockeduntil.app
+
+import android.os.Bundle
+import android.widget.Button
+import android.widget.EditText
+import android.widget.TextView
+import androidx.appcompat.app.AppCompatActivity
+
+import java.util.Locale
+import org.json.JSONObject
+
+import okhttp3.OkHttpClient
+import okhttp3.Request
+import okhttp3.MediaType.Companion.toMediaType
+import okhttp3.RequestBody.Companion.toRequestBody
+import okhttp3.Call
+import okhttp3.Callback
+import okhttp3.Response
+import java.io.IOException
+
+class StoreActivity : AppCompatActivity() {
+    private val client = OkHttpClient()
+    private val baseUrl = "http://10.0.2.2:8080"
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        setContentView(R.layout.activity_store)
+
+        val lang = if (Locale.getDefault().language == "tr") "tr" else "en"
+
+        val secretInput = findViewById<EditText>(R.id.secretInput)
+        val emailInput = findViewById<EditText>(R.id.emailInput)
+        val masterPassInput = findViewById<EditText>(R.id.masterPassInput)
+        val viewPassInput = findViewById<EditText>(R.id.viewPassInput)
+        val dateInput = findViewById<EditText>(R.id.dateInput)
+        val storeButton = findViewById<Button>(R.id.storeButton)
+        val storeResult = findViewById<TextView>(R.id.storeResult)
+
+        storeButton.setOnClickListener {
+            val json = JSONObject().apply {
+                put("secret", secretInput.text.toString())
+                put("email", emailInput.text.toString())
+                put("masterPass", masterPassInput.text.toString())
+                put("viewPass", viewPassInput.text.toString())
+                put("lang", lang)
+                val d = dateInput.text.toString()
+                if (d.isNotEmpty()) put("unlockDate", d)
+            }
+            val reqBody = json.toString().toRequestBody(JSON)
+            val request = Request.Builder().url("$baseUrl/api/store").post(reqBody).build()
+            client.newCall(request).enqueue(object : Callback {
+                override fun onFailure(call: Call, e: IOException) {
+                    runOnUiThread { storeResult.text = e.message }
+                }
+                override fun onResponse(call: Call, response: Response) {
+                    val body = response.body?.string() ?: ""
+                    runOnUiThread { storeResult.text = body }
+                }
+            })
+        }
+
+    }
+
+    companion object {
+        private val JSON = "application/json; charset=utf-8".toMediaType()
+    }
+}

--- a/android/app/src/main/java/com/example/lockeduntil/UseCasesActivity.kt
+++ b/android/app/src/main/java/com/example/lockeduntil/UseCasesActivity.kt
@@ -1,0 +1,11 @@
+package com.lockeduntil.app
+
+import android.os.Bundle
+import androidx.appcompat.app.AppCompatActivity
+
+class UseCasesActivity : AppCompatActivity() {
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        setContentView(R.layout.activity_use_cases)
+    }
+}

--- a/android/app/src/main/java/com/example/lockeduntil/WhyTrustActivity.kt
+++ b/android/app/src/main/java/com/example/lockeduntil/WhyTrustActivity.kt
@@ -1,0 +1,11 @@
+package com.lockeduntil.app
+
+import android.os.Bundle
+import androidx.appcompat.app.AppCompatActivity
+
+class WhyTrustActivity : AppCompatActivity() {
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        setContentView(R.layout.activity_why_trust)
+    }
+}

--- a/android/app/src/main/res/layout/activity_home.xml
+++ b/android/app/src/main/res/layout/activity_home.xml
@@ -1,0 +1,44 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:orientation="vertical"
+    android:padding="24dp"
+    android:background="@color/bg_dark">
+
+    <Button
+        android:id="@+id/btnStore"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:text="@string/home_store"
+        android:backgroundTint="@color/teal"
+        android:textColor="@color/white" />
+
+    <Button
+        android:id="@+id/btnRetrieve"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:text="@string/home_retrieve"
+        android:backgroundTint="@color/orange"
+        android:textColor="@color/white"
+        android:layout_marginTop="16dp" />
+
+    <Button
+        android:id="@+id/btnWhyTrust"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:text="@string/home_why_trust"
+        android:backgroundTint="@color/teal"
+        android:textColor="@color/white"
+        android:layout_marginTop="16dp" />
+
+    <Button
+        android:id="@+id/btnUseCases"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:text="@string/home_use_cases"
+        android:backgroundTint="@color/teal"
+        android:textColor="@color/white"
+        android:layout_marginTop="16dp" />
+
+</LinearLayout>

--- a/android/app/src/main/res/layout/activity_retrieve.xml
+++ b/android/app/src/main/res/layout/activity_retrieve.xml
@@ -1,0 +1,50 @@
+<?xml version="1.0" encoding="utf-8"?>
+<ScrollView xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:background="@color/orange">
+
+    <LinearLayout
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:orientation="vertical"
+        android:padding="16dp">
+
+        <TextView
+            android:id="@+id/retrieveTitle"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:text="@string/retrieve_title"
+            android:textStyle="bold"
+            android:textColor="@color/white" />
+
+        <EditText
+            android:id="@+id/idInput"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:hint="@string/hint_id"
+            android:background="@android:color/white"/>
+
+        <EditText
+            android:id="@+id/passInput"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:hint="@string/hint_password"
+            android:background="@android:color/white"/>
+
+        <Button
+            android:id="@+id/retrieveButton"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:text="@string/retrieve_button"
+            android:backgroundTint="@color/green"
+            android:textColor="@color/bg_dark"/>
+
+        <TextView
+            android:id="@+id/retrieveResult"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:textColor="@color/white"/>
+
+    </LinearLayout>
+</ScrollView>

--- a/android/app/src/main/res/layout/activity_store.xml
+++ b/android/app/src/main/res/layout/activity_store.xml
@@ -1,7 +1,8 @@
 <?xml version="1.0" encoding="utf-8"?>
 <ScrollView xmlns:android="http://schemas.android.com/apk/res/android"
     android:layout_width="match_parent"
-    android:layout_height="match_parent">
+    android:layout_height="match_parent"
+    android:background="@color/teal">
 
     <LinearLayout
         android:layout_width="match_parent"
@@ -14,85 +15,57 @@
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:text="@string/store_title"
-            android:textStyle="bold" />
+            android:textStyle="bold"
+            android:textColor="@color/white" />
 
         <EditText
             android:id="@+id/secretInput"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            android:hint="@string/hint_secret"/>
+            android:hint="@string/hint_secret"
+            android:background="@android:color/white"/>
 
         <EditText
             android:id="@+id/emailInput"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            android:hint="@string/hint_email"/>
+            android:hint="@string/hint_email"
+            android:background="@android:color/white"/>
 
         <EditText
             android:id="@+id/masterPassInput"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            android:hint="@string/hint_master"/>
+            android:hint="@string/hint_master"
+            android:background="@android:color/white"/>
 
         <EditText
             android:id="@+id/viewPassInput"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            android:hint="@string/hint_view"/>
+            android:hint="@string/hint_view"
+            android:background="@android:color/white"/>
 
         <EditText
             android:id="@+id/dateInput"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            android:hint="@string/hint_date"/>
+            android:hint="@string/hint_date"
+            android:background="@android:color/white"/>
 
         <Button
             android:id="@+id/storeButton"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
-            android:text="@string/store_button"/>
+            android:text="@string/store_button"
+            android:backgroundTint="@color/green"
+            android:textColor="@color/bg_dark"/>
 
         <TextView
             android:id="@+id/storeResult"
             android:layout_width="wrap_content"
-            android:layout_height="wrap_content"/>
-
-        <View
-            android:layout_width="match_parent"
-            android:layout_height="1dp"
-            android:background="#CCCCCC"
-            android:layout_marginTop="16dp"
-            android:layout_marginBottom="16dp"/>
-
-        <TextView
-            android:id="@+id/retrieveTitle"
-            android:layout_width="wrap_content"
             android:layout_height="wrap_content"
-            android:text="@string/retrieve_title"
-            android:textStyle="bold" />
-
-        <EditText
-            android:id="@+id/idInput"
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:hint="@string/hint_id"/>
-
-        <EditText
-            android:id="@+id/passInput"
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:hint="@string/hint_password"/>
-
-        <Button
-            android:id="@+id/retrieveButton"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:text="@string/retrieve_button"/>
-
-        <TextView
-            android:id="@+id/retrieveResult"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"/>
+            android:textColor="@color/white"/>
 
     </LinearLayout>
 </ScrollView>

--- a/android/app/src/main/res/layout/activity_use_cases.xml
+++ b/android/app/src/main/res/layout/activity_use_cases.xml
@@ -1,0 +1,86 @@
+<?xml version="1.0" encoding="utf-8"?>
+<ScrollView xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:background="@color/teal">
+
+    <LinearLayout
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:orientation="vertical"
+        android:padding="16dp">
+
+        <TextView
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:text="@string/use_cases_title"
+            android:textStyle="bold"
+            android:textColor="@color/white" />
+
+        <TextView
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:text="@string/case_invest_title"
+            android:textStyle="bold"
+            android:textColor="@color/white"
+            android:layout_marginTop="8dp"/>
+        <TextView
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:text="@string/case_invest_desc"
+            android:textColor="@color/white"/>
+
+        <TextView
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:text="@string/case_will_title"
+            android:textStyle="bold"
+            android:textColor="@color/white"
+            android:layout_marginTop="8dp"/>
+        <TextView
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:text="@string/case_will_desc"
+            android:textColor="@color/white"/>
+
+        <TextView
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:text="@string/case_emergency_title"
+            android:textStyle="bold"
+            android:textColor="@color/white"
+            android:layout_marginTop="8dp"/>
+        <TextView
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:text="@string/case_emergency_desc"
+            android:textColor="@color/white"/>
+
+        <TextView
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:text="@string/case_exposure_title"
+            android:textStyle="bold"
+            android:textColor="@color/white"
+            android:layout_marginTop="8dp"/>
+        <TextView
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:text="@string/case_exposure_desc"
+            android:textColor="@color/white"/>
+
+        <TextView
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:text="@string/case_treasure_title"
+            android:textStyle="bold"
+            android:textColor="@color/white"
+            android:layout_marginTop="8dp"/>
+        <TextView
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:text="@string/case_treasure_desc"
+            android:textColor="@color/white"/>
+
+    </LinearLayout>
+</ScrollView>

--- a/android/app/src/main/res/layout/activity_why_trust.xml
+++ b/android/app/src/main/res/layout/activity_why_trust.xml
@@ -1,0 +1,42 @@
+<?xml version="1.0" encoding="utf-8"?>
+<ScrollView xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:background="@color/teal">
+
+    <LinearLayout
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:orientation="vertical"
+        android:padding="16dp">
+
+        <TextView
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:text="@string/why_trust_title"
+            android:textStyle="bold"
+            android:textColor="@color/white" />
+
+        <TextView
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:text="@string/why_trust_p1"
+            android:textColor="@color/white"
+            android:layout_marginTop="8dp"/>
+
+        <TextView
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:text="@string/why_trust_p2"
+            android:textColor="@color/white"
+            android:layout_marginTop="8dp"/>
+
+        <TextView
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:text="@string/why_trust_p3"
+            android:textColor="@color/white"
+            android:layout_marginTop="8dp"/>
+
+    </LinearLayout>
+</ScrollView>

--- a/android/app/src/main/res/values-night/colors.xml
+++ b/android/app/src/main/res/values-night/colors.xml
@@ -1,0 +1,7 @@
+<resources>
+    <color name="bg_dark">#0f172a</color>
+    <color name="teal">#0ea5a9</color>
+    <color name="green">#10b981</color>
+    <color name="orange">#f97316</color>
+    <color name="white">#ffffff</color>
+</resources>

--- a/android/app/src/main/res/values-tr/strings.xml
+++ b/android/app/src/main/res/values-tr/strings.xml
@@ -16,8 +16,8 @@
     <string name="home_why_trust">Neden Güvenmelisiniz</string>
     <string name="home_use_cases">Kullanım Senaryoları</string>
     <string name="why_trust_title">Neden Güvenebilirsiniz?</string>
-    <string name="why_trust_p1">Tüm kaynak kodu GitHub'da açık.</string>
-    <string name="why_trust_p2">Şifreler ve ID'ler sunucuda saklanmaz.</string>
+    <string name="why_trust_p1">Tüm kaynak kodu GitHub&#39;da açık.</string>
+    <string name="why_trust_p2">Şifreler ve ID&#39;ler sunucuda saklanmaz.</string>
     <string name="why_trust_p3">Veriler gönderilmeden önce cihazınızda şifrelenir.</string>
     <string name="use_cases_title">Kullanım Senaryoları</string>
     <string name="case_invest_title">Yatırım Disiplini</string>

--- a/android/app/src/main/res/values-tr/strings.xml
+++ b/android/app/src/main/res/values-tr/strings.xml
@@ -16,8 +16,8 @@
     <string name="home_why_trust">Neden Güvenmelisiniz</string>
     <string name="home_use_cases">Kullanım Senaryoları</string>
     <string name="why_trust_title">Neden Güvenebilirsiniz?</string>
-    <string name="why_trust_p1">Tüm kaynak kodu GitHub'da açık.</string>
-    <string name="why_trust_p2">Şifreler ve ID'ler sunucuda saklanmaz.</string>
+    <string name="why_trust_p1">Tüm kaynak kodu GitHub da açık.</string>
+    <string name="why_trust_p2">Şifreler ve ID ler sunucuda saklanmaz.</string>
     <string name="why_trust_p3">Veriler gönderilmeden önce cihazınızda şifrelenir.</string>
     <string name="use_cases_title">Kullanım Senaryoları</string>
     <string name="case_invest_title">Yatırım Disiplini</string>

--- a/android/app/src/main/res/values-tr/strings.xml
+++ b/android/app/src/main/res/values-tr/strings.xml
@@ -11,4 +11,23 @@
     <string name="hint_id">ID</string>
     <string name="hint_password">Parola</string>
     <string name="retrieve_button">Çöz</string>
+    <string name="home_store">Kaydet</string>
+    <string name="home_retrieve">Geri Al</string>
+    <string name="home_why_trust">Neden Güvenmelisiniz</string>
+    <string name="home_use_cases">Kullanım Senaryoları</string>
+    <string name="why_trust_title">Neden Güvenebilirsiniz?</string>
+    <string name="why_trust_p1">Tüm kaynak kodu GitHub'da açık.</string>
+    <string name="why_trust_p2">Şifreler ve ID'ler sunucuda saklanmaz.</string>
+    <string name="why_trust_p3">Veriler gönderilmeden önce cihazınızda şifrelenir.</string>
+    <string name="use_cases_title">Kullanım Senaryoları</string>
+    <string name="case_invest_title">Yatırım Disiplini</string>
+    <string name="case_invest_desc">Panik satışını önlemek için talimatları kilitleyin.</string>
+    <string name="case_will_title">Vasiyet / Son İstek</string>
+    <string name="case_will_desc">Son dileklerinizi güvenle saklayın.</string>
+    <string name="case_emergency_title">Acil Durum Paylaşımı</string>
+    <string name="case_emergency_desc">Size bir şey olursa kritik verileri iletin.</string>
+    <string name="case_exposure_title">Tehdit / İfşa Senaryosu</string>
+    <string name="case_exposure_desc">Delilleri gerektiğinde ortaya çıkarın.</string>
+    <string name="case_treasure_title">Kıymetli Emanet Bildirimi</string>
+    <string name="case_treasure_desc">Kıymetli eşyaların yerini güvenle paylaşın.</string>
 </resources>

--- a/android/app/src/main/res/values-tr/strings.xml
+++ b/android/app/src/main/res/values-tr/strings.xml
@@ -16,8 +16,8 @@
     <string name="home_why_trust">Neden Güvenmelisiniz</string>
     <string name="home_use_cases">Kullanım Senaryoları</string>
     <string name="why_trust_title">Neden Güvenebilirsiniz?</string>
-    <string name="why_trust_p1">Tüm kaynak kodu GitHub&#39;da açık.</string>
-    <string name="why_trust_p2">Şifreler ve ID&#39;ler sunucuda saklanmaz.</string>
+    <string name="why_trust_p1">Tüm kaynak kodu GitHub'da açık.</string>
+    <string name="why_trust_p2">Şifreler ve ID'ler sunucuda saklanmaz.</string>
     <string name="why_trust_p3">Veriler gönderilmeden önce cihazınızda şifrelenir.</string>
     <string name="use_cases_title">Kullanım Senaryoları</string>
     <string name="case_invest_title">Yatırım Disiplini</string>

--- a/android/app/src/main/res/values/colors.xml
+++ b/android/app/src/main/res/values/colors.xml
@@ -1,0 +1,7 @@
+<resources>
+    <color name="bg_dark">#0f172a</color>
+    <color name="teal">#0ea5a9</color>
+    <color name="green">#10b981</color>
+    <color name="orange">#f97316</color>
+    <color name="white">#ffffff</color>
+</resources>

--- a/android/app/src/main/res/values/strings.xml
+++ b/android/app/src/main/res/values/strings.xml
@@ -11,4 +11,23 @@
     <string name="hint_id">ID</string>
     <string name="hint_password">Password</string>
     <string name="retrieve_button">Retrieve</string>
+    <string name="home_store">Store</string>
+    <string name="home_retrieve">Retrieve</string>
+    <string name="home_why_trust">Why Trust</string>
+    <string name="home_use_cases">Use Cases</string>
+    <string name="why_trust_title">Why Trust?</string>
+    <string name="why_trust_p1">All source code is open on GitHub.</string>
+    <string name="why_trust_p2">Secrets and IDs are never stored on the server.</string>
+    <string name="why_trust_p3">Data is encrypted on your device before sending.</string>
+    <string name="use_cases_title">Use Cases</string>
+    <string name="case_invest_title">Investment Discipline</string>
+    <string name="case_invest_desc">Lock instructions to avoid panic selling.</string>
+    <string name="case_will_title">Will / Final Wish</string>
+    <string name="case_will_desc">Store your last wishes securely.</string>
+    <string name="case_emergency_title">Emergency Sharing</string>
+    <string name="case_emergency_desc">Deliver critical data if something happens.</string>
+    <string name="case_exposure_title">Threat / Exposure Scenario</string>
+    <string name="case_exposure_desc">Release evidence only when needed.</string>
+    <string name="case_treasure_title">Precious Deposit Notice</string>
+    <string name="case_treasure_desc">Share the location of valuables safely.</string>
 </resources>


### PR DESCRIPTION
## Summary
- Add a home screen with navigation buttons for storing, retrieving, trust info, and use cases
- Separate store/retrieve features into their own activities and layouts
- Include informational pages and shared color palette matching the website

## Testing
- `./gradlew lint` *(fails: Unable to tunnel through proxy, HTTP 403)*

------
https://chatgpt.com/codex/tasks/task_e_68a1c0ed8a088331ba9bddd977960b1d