### PR TITLE
Add title field, date picker, and style fixes

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -6,6 +6,7 @@
         android:allowBackup="true"
         android:label="@string/app_name"
         android:supportsRtl="true"
+        android:usesCleartextTraffic="true"
         android:theme="@style/Theme.LockedUntil">
 
         <activity

--- a/android/app/src/main/java/com/example/lockeduntil/MainActivity.kt
+++ b/android/app/src/main/java/com/example/lockeduntil/MainActivity.kt
@@ -14,7 +14,6 @@ class MainActivity : AppCompatActivity() {
         val storeButton = findViewById<Button>(R.id.storeActivityButton)
         val retrieveButton = findViewById<Button>(R.id.retrieveActivityButton)
         val useCasesButton = findViewById<Button>(R.id.useCasesButton)
-        val whyTrustButton = findViewById<Button>(R.id.whyTrustButton)
         val settingsButton = findViewById<ImageButton>(R.id.settingsButton)
 
         storeButton.setOnClickListener {
@@ -27,10 +26,6 @@ class MainActivity : AppCompatActivity() {
 
         useCasesButton.setOnClickListener {
             startActivity(Intent(this, UseCasesActivity::class.java))
-        }
-
-        whyTrustButton.setOnClickListener {
-            startActivity(Intent(this, WhyTrustActivity::class.java))
         }
 
         settingsButton.setOnClickListener {

--- a/android/app/src/main/java/com/example/lockeduntil/StoreActivity.kt
+++ b/android/app/src/main/java/com/example/lockeduntil/StoreActivity.kt
@@ -1,5 +1,6 @@
 package com.lockeduntil.app
 
+import android.app.DatePickerDialog
 import android.content.Intent
 import android.os.Bundle
 import android.widget.Button
@@ -7,6 +8,7 @@ import android.widget.EditText
 import android.widget.ImageButton
 import android.widget.TextView
 import androidx.appcompat.app.AppCompatActivity
+import java.util.Calendar
 import java.util.Locale
 import org.json.JSONObject
 import okhttp3.Call
@@ -28,6 +30,7 @@ class StoreActivity : AppCompatActivity() {
 
         val lang = if (Locale.getDefault().language == "tr") "tr" else "en"
 
+        val titleInput = findViewById<EditText>(R.id.titleInput)
         val secretInput = findViewById<EditText>(R.id.secretInput)
         val emailInput = findViewById<EditText>(R.id.emailInput)
         val masterPassInput = findViewById<EditText>(R.id.masterPassInput)
@@ -43,8 +46,24 @@ class StoreActivity : AppCompatActivity() {
             startActivity(Intent(this, SettingsActivity::class.java))
         }
 
+        dateInput.setOnClickListener {
+            val calendar = Calendar.getInstance()
+            DatePickerDialog(
+                this,
+                { _, year, month, dayOfMonth ->
+                    val m = (month + 1).toString().padStart(2, '0')
+                    val d = dayOfMonth.toString().padStart(2, '0')
+                    dateInput.setText("$year-$m-$d")
+                },
+                calendar.get(Calendar.YEAR),
+                calendar.get(Calendar.MONTH),
+                calendar.get(Calendar.DAY_OF_MONTH)
+            ).show()
+        }
+
         storeButton.setOnClickListener {
             val json = JSONObject().apply {
+                put("title", titleInput.text.toString())
                 put("secret", secretInput.text.toString())
                 put("email", emailInput.text.toString())
                 put("masterPass", masterPassInput.text.toString())

--- a/android/app/src/main/res/drawable/background_gradient_retrieve.xml
+++ b/android/app/src/main/res/drawable/background_gradient_retrieve.xml
@@ -1,0 +1,6 @@
+<shape xmlns:android="http://schemas.android.com/apk/res/android">
+    <gradient
+        android:startColor="#0f172a"
+        android:endColor="#f97316"
+        android:angle="135" />
+</shape>

--- a/android/app/src/main/res/drawable/button_bg.xml
+++ b/android/app/src/main/res/drawable/button_bg.xml
@@ -1,5 +1,5 @@
 <shape xmlns:android="http://schemas.android.com/apk/res/android">
-    <solid android:color="#34d399" />
+    <solid android:color="#0FB07B" />
     <corners android:radius="12dp" />
     <padding android:left="16dp" android:top="8dp" android:right="16dp" android:bottom="8dp" />
 </shape>

--- a/android/app/src/main/res/drawable/card_bg.xml
+++ b/android/app/src/main/res/drawable/card_bg.xml
@@ -1,0 +1,4 @@
+<shape xmlns:android="http://schemas.android.com/apk/res/android">
+    <solid android:color="#FFFFFF" />
+    <corners android:radius="8dp" />
+</shape>

--- a/android/app/src/main/res/drawable/ic_lock_open.xml
+++ b/android/app/src/main/res/drawable/ic_lock_open.xml
@@ -1,9 +1,0 @@
-<vector xmlns:android="http://schemas.android.com/apk/res/android"
-    android:width="24dp"
-    android:height="24dp"
-    android:viewportWidth="24"
-    android:viewportHeight="24">
-    <path
-        android:fillColor="#071019"
-        android:pathData="M12,17c1.1,0 2,-0.9 2,-2s-0.9,-2 -2,-2 -2,0.9 -2,2 0.9,2 2,2zM17,8h-1V6c0,-2.76 -2.24,-5 -5,-5S6,3.24 6,6h2c0,-1.66 1.34,-3 3,-3s3,1.34 3,3v2H7c-1.1,0 -2,0.9 -2,2v10c0,1.1 0.9,2 2,2h10c1.1,0 2,-0.9 2,-2V10c0,-1.1 -0.9,-2 -2,-2z"/>
-</vector>

--- a/android/app/src/main/res/drawable/ic_lock_open.xml
+++ b/android/app/src/main/res/drawable/ic_lock_open.xml
@@ -1,0 +1,9 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+    <path
+        android:fillColor="#071019"
+        android:pathData="M12,17c1.1,0 2,-0.9 2,-2s-0.9,-2 -2,-2 -2,0.9 -2,2 0.9,2 2,2zM17,8h-1V6c0,-2.76 -2.24,-5 -5,-5S6,3.24 6,6h2c0,-1.66 1.34,-3 3,-3s3,1.34 3,3v2H7c-1.1,0 -2,0.9 -2,2v10c0,1.1 0.9,2 2,2h10c1.1,0 2,-0.9 2,-2V10c0,-1.1 -0.9,-2 -2,-2z"/>
+</vector>

--- a/android/app/src/main/res/layout/activity_main.xml
+++ b/android/app/src/main/res/layout/activity_main.xml
@@ -12,7 +12,7 @@
         android:layout_height="wrap_content"
         android:layout_gravity="end"
         android:background="@drawable/button_bg"
-        android:backgroundTint="@null"
+        android:backgroundTint="@android:color/transparent"
         android:src="@android:drawable/ic_menu_manage"
         android:contentDescription="@string/settings" />
 
@@ -32,10 +32,10 @@
         android:text="@string/tagline_sub" />
 
     <GridLayout
-        android:layout_width="match_parent"
-        android:layout_height="0dp"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
         android:layout_marginTop="16dp"
-        android:layout_weight="1"
+        android:layout_gravity="center"
         android:columnCount="2"
         android:rowCount="2"
         android:alignmentMode="alignMargins"
@@ -49,7 +49,7 @@
             android:layout_gravity="center"
             android:text="@string/store_title"
             android:background="@drawable/button_bg"
-            android:backgroundTint="@null"
+            android:backgroundTint="@android:color/transparent"
             android:textColor="#071019" />
 
         <Button
@@ -60,7 +60,9 @@
             android:layout_gravity="center"
             android:text="@string/retrieve_title"
             android:background="@drawable/button_bg"
-            android:backgroundTint="@null"
+            android:backgroundTint="@android:color/transparent"
+            android:drawableTop="@drawable/ic_lock_open"
+            android:drawablePadding="4dp"
             android:textColor="#071019" />
 
         <Button
@@ -71,7 +73,7 @@
             android:layout_gravity="center"
             android:text="@string/use_cases_button"
             android:background="@drawable/button_bg"
-            android:backgroundTint="@null"
+            android:backgroundTint="@android:color/transparent"
             android:textColor="#071019" />
 
         <Button
@@ -82,7 +84,7 @@
             android:layout_gravity="center"
             android:text="@string/why_trust_button"
             android:background="@drawable/button_bg"
-            android:backgroundTint="@null"
+            android:backgroundTint="@android:color/transparent"
             android:textColor="#071019" />
 
     </GridLayout>

--- a/android/app/src/main/res/layout/activity_main.xml
+++ b/android/app/src/main/res/layout/activity_main.xml
@@ -43,11 +43,10 @@
 
         <Button
             android:id="@+id/storeActivityButton"
-            android:layout_width="0dp"
-            android:layout_height="0dp"
-            android:layout_columnWeight="1"
-            android:layout_rowWeight="1"
+            android:layout_width="120dp"
+            android:layout_height="120dp"
             android:layout_margin="8dp"
+            android:layout_gravity="center"
             android:text="@string/store_title"
             android:background="@drawable/button_bg"
             android:backgroundTint="@null"
@@ -55,11 +54,10 @@
 
         <Button
             android:id="@+id/retrieveActivityButton"
-            android:layout_width="0dp"
-            android:layout_height="0dp"
-            android:layout_columnWeight="1"
-            android:layout_rowWeight="1"
+            android:layout_width="120dp"
+            android:layout_height="120dp"
             android:layout_margin="8dp"
+            android:layout_gravity="center"
             android:text="@string/retrieve_title"
             android:background="@drawable/button_bg"
             android:backgroundTint="@null"
@@ -67,11 +65,10 @@
 
         <Button
             android:id="@+id/useCasesButton"
-            android:layout_width="0dp"
-            android:layout_height="0dp"
-            android:layout_columnWeight="1"
-            android:layout_rowWeight="1"
+            android:layout_width="120dp"
+            android:layout_height="120dp"
             android:layout_margin="8dp"
+            android:layout_gravity="center"
             android:text="@string/use_cases_button"
             android:background="@drawable/button_bg"
             android:backgroundTint="@null"
@@ -79,11 +76,10 @@
 
         <Button
             android:id="@+id/whyTrustButton"
-            android:layout_width="0dp"
-            android:layout_height="0dp"
-            android:layout_columnWeight="1"
-            android:layout_rowWeight="1"
+            android:layout_width="120dp"
+            android:layout_height="120dp"
             android:layout_margin="8dp"
+            android:layout_gravity="center"
             android:text="@string/why_trust_button"
             android:background="@drawable/button_bg"
             android:backgroundTint="@null"

--- a/android/app/src/main/res/layout/activity_main.xml
+++ b/android/app/src/main/res/layout/activity_main.xml
@@ -31,62 +31,90 @@
         android:layout_marginTop="4dp"
         android:text="@string/tagline_sub" />
 
-    <GridLayout
-        android:layout_width="wrap_content"
+    <LinearLayout
+        android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:layout_marginTop="16dp"
-        android:layout_gravity="center"
-        android:columnCount="2"
-        android:rowCount="2"
-        android:alignmentMode="alignMargins"
-        android:rowOrderPreserved="false">
+        android:orientation="vertical">
 
-        <Button
-            android:id="@+id/storeActivityButton"
-            android:layout_width="120dp"
-            android:layout_height="120dp"
-            android:layout_margin="8dp"
-            android:layout_gravity="center"
-            android:text="@string/store_title"
-            android:background="@drawable/button_bg"
-            android:backgroundTint="@android:color/transparent"
-            android:textColor="#071019" />
+        <LinearLayout
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="8dp"
+            android:background="@drawable/card_bg"
+            android:elevation="2dp"
+            android:orientation="vertical"
+            android:padding="16dp">
 
-        <Button
-            android:id="@+id/retrieveActivityButton"
-            android:layout_width="120dp"
-            android:layout_height="120dp"
-            android:layout_margin="8dp"
-            android:layout_gravity="center"
-            android:text="@string/retrieve_title"
-            android:background="@drawable/button_bg"
-            android:backgroundTint="@android:color/transparent"
-            android:drawableTop="@drawable/ic_lock_open"
-            android:drawablePadding="4dp"
-            android:textColor="#071019" />
+            <Button
+                android:id="@+id/storeActivityButton"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:background="@drawable/button_bg"
+                android:backgroundTint="@android:color/transparent"
+                android:text="@string/store_title"
+                android:textColor="@android:color/white" />
 
-        <Button
-            android:id="@+id/useCasesButton"
-            android:layout_width="120dp"
-            android:layout_height="120dp"
-            android:layout_margin="8dp"
-            android:layout_gravity="center"
-            android:text="@string/use_cases_button"
-            android:background="@drawable/button_bg"
-            android:backgroundTint="@android:color/transparent"
-            android:textColor="#071019" />
+            <TextView
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="8dp"
+                android:text="@string/home_store_desc" />
 
-        <Button
-            android:id="@+id/whyTrustButton"
-            android:layout_width="120dp"
-            android:layout_height="120dp"
-            android:layout_margin="8dp"
-            android:layout_gravity="center"
-            android:text="@string/why_trust_button"
-            android:background="@drawable/button_bg"
-            android:backgroundTint="@android:color/transparent"
-            android:textColor="#071019" />
+        </LinearLayout>
 
-    </GridLayout>
+        <LinearLayout
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="8dp"
+            android:background="@drawable/card_bg"
+            android:elevation="2dp"
+            android:orientation="vertical"
+            android:padding="16dp">
+
+            <Button
+                android:id="@+id/retrieveActivityButton"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:background="@drawable/button_bg"
+                android:backgroundTint="@android:color/transparent"
+                android:text="@string/retrieve_title"
+                android:textColor="@android:color/white" />
+
+            <TextView
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="8dp"
+                android:text="@string/home_retrieve_desc" />
+
+        </LinearLayout>
+
+        <LinearLayout
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="8dp"
+            android:background="@drawable/card_bg"
+            android:elevation="2dp"
+            android:orientation="vertical"
+            android:padding="16dp">
+
+            <Button
+                android:id="@+id/useCasesButton"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:background="@drawable/button_bg"
+                android:backgroundTint="@android:color/transparent"
+                android:text="@string/use_cases_button"
+                android:textColor="@android:color/white" />
+
+            <TextView
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="8dp"
+                android:text="@string/home_use_cases_desc" />
+
+        </LinearLayout>
+
+    </LinearLayout>
 
 </LinearLayout>

--- a/android/app/src/main/res/layout/activity_retrieve.xml
+++ b/android/app/src/main/res/layout/activity_retrieve.xml
@@ -2,7 +2,7 @@
 <ScrollView xmlns:android="http://schemas.android.com/apk/res/android"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
-    android:background="@drawable/background_gradient">
+    android:background="@drawable/background_gradient_retrieve">
 
     <LinearLayout
         android:layout_width="match_parent"
@@ -46,6 +46,12 @@
             android:text="@string/retrieve_title"
             android:textStyle="bold"
             android:textSize="24sp" />
+
+        <TextView
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="8dp"
+            android:text="@string/retrieve_desc" />
 
         <EditText
             android:id="@+id/idInput"

--- a/android/app/src/main/res/layout/activity_retrieve.xml
+++ b/android/app/src/main/res/layout/activity_retrieve.xml
@@ -21,7 +21,7 @@
                 android:layout_height="wrap_content"
                 android:text="@string/home_button"
                 android:background="@drawable/button_bg"
-                android:backgroundTint="@null"
+                android:backgroundTint="@android:color/transparent"
                 android:textColor="#071019" />
 
             <View
@@ -34,7 +34,7 @@
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
                 android:background="@drawable/button_bg"
-                android:backgroundTint="@null"
+                android:backgroundTint="@android:color/transparent"
                 android:src="@android:drawable/ic_menu_manage"
                 android:contentDescription="@string/settings" />
         </LinearLayout>
@@ -74,7 +74,7 @@
             android:layout_marginTop="8dp"
             android:text="@string/retrieve_button"
             android:background="@drawable/button_bg"
-            android:backgroundTint="@null"
+            android:backgroundTint="@android:color/transparent"
             android:textColor="#071019"/>
 
         <TextView

--- a/android/app/src/main/res/layout/activity_settings.xml
+++ b/android/app/src/main/res/layout/activity_settings.xml
@@ -17,7 +17,7 @@
             android:layout_height="wrap_content"
             android:text="@string/home_button"
             android:background="@drawable/button_bg"
-            android:backgroundTint="@null"
+            android:backgroundTint="@android:color/transparent"
             android:textColor="#071019" />
     </LinearLayout>
 

--- a/android/app/src/main/res/layout/activity_store.xml
+++ b/android/app/src/main/res/layout/activity_store.xml
@@ -21,7 +21,7 @@
                 android:layout_height="wrap_content"
                 android:text="@string/home_button"
                 android:background="@drawable/button_bg"
-                android:backgroundTint="@null"
+                android:backgroundTint="@android:color/transparent"
                 android:textColor="#071019" />
 
             <View
@@ -34,7 +34,7 @@
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
                 android:background="@drawable/button_bg"
-                android:backgroundTint="@null"
+                android:backgroundTint="@android:color/transparent"
                 android:src="@android:drawable/ic_menu_manage"
                 android:contentDescription="@string/settings" />
         </LinearLayout>
@@ -104,7 +104,7 @@
             android:layout_marginTop="8dp"
             android:text="@string/store_button"
             android:background="@drawable/button_bg"
-            android:backgroundTint="@null"
+            android:backgroundTint="@android:color/transparent"
             android:textColor="#071019"/>
 
         <TextView

--- a/android/app/src/main/res/layout/activity_store.xml
+++ b/android/app/src/main/res/layout/activity_store.xml
@@ -47,6 +47,19 @@
             android:textStyle="bold"
             android:textSize="24sp" />
 
+        <TextView
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="8dp"
+            android:text="@string/store_desc" />
+
+        <EditText
+            android:id="@+id/titleInput"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:hint="@string/hint_title"
+            android:textColorHint="#9AA0A6"/>
+
         <EditText
             android:id="@+id/secretInput"
             android:layout_width="match_parent"
@@ -80,6 +93,8 @@
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
             android:hint="@string/hint_date"
+            android:focusable="false"
+            android:clickable="true"
             android:textColorHint="#9AA0A6"/>
 
         <Button

--- a/android/app/src/main/res/layout/activity_use_cases.xml
+++ b/android/app/src/main/res/layout/activity_use_cases.xml
@@ -21,7 +21,7 @@
                 android:layout_height="wrap_content"
                 android:text="@string/home_button"
                 android:background="@drawable/button_bg"
-                android:backgroundTint="@null"
+                android:backgroundTint="@android:color/transparent"
                 android:textColor="#071019" />
 
             <View
@@ -34,7 +34,7 @@
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
                 android:background="@drawable/button_bg"
-                android:backgroundTint="@null"
+                android:backgroundTint="@android:color/transparent"
                 android:src="@android:drawable/ic_menu_manage"
                 android:contentDescription="@string/settings" />
         </LinearLayout>

--- a/android/app/src/main/res/layout/activity_why_trust.xml
+++ b/android/app/src/main/res/layout/activity_why_trust.xml
@@ -21,7 +21,7 @@
                 android:layout_height="wrap_content"
                 android:text="@string/home_button"
                 android:background="@drawable/button_bg"
-                android:backgroundTint="@null"
+                android:backgroundTint="@android:color/transparent"
                 android:textColor="#071019" />
 
             <View
@@ -34,7 +34,7 @@
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
                 android:background="@drawable/button_bg"
-                android:backgroundTint="@null"
+                android:backgroundTint="@android:color/transparent"
                 android:src="@android:drawable/ic_menu_manage"
                 android:contentDescription="@string/settings" />
         </LinearLayout>

--- a/android/app/src/main/res/values-tr/strings.xml
+++ b/android/app/src/main/res/values-tr/strings.xml
@@ -18,6 +18,9 @@
     <string name="why_trust_button">🛡️ Neden Güvenebilirsiniz</string>
     <string name="home_button">Ana Sayfa</string>
     <string name="toggle_language">Dili Değiştir</string>
+    <string name="home_store_desc">Metninizi veya talimatınızı şifreleyip zaman kilidi ekleyin. Belirlediğiniz tarih gelene kadar erişim mümkün değildir.</string>
+    <string name="home_retrieve_desc">Kimlik bilgileri ve parolanızla kayıtlı içeriği alın. Zaman kilidi varsa erişim tarihi beklenmelidir.</string>
+    <string name="home_use_cases_desc">Vasiyet metni, acil durum paylaşımı veya panik satış önleme gibi farklı senaryoları keşfedin.</string>
     <string name="use_cases_title">Kullanım Senaryoları</string>
     <string name="use_cases_investment_title">Yatırım Disiplini</string>
     <string name="use_cases_investment_desc">Panik satışını önlemek için kendi talimatlarınızı geleceğe kilitleyerek duygusal kararları sınırlandırır.</string>

--- a/android/app/src/main/res/values-tr/strings.xml
+++ b/android/app/src/main/res/values-tr/strings.xml
@@ -7,7 +7,10 @@
     <string name="hint_view">Görüntüleme parolası</string>
     <string name="hint_date">Açılma tarihi (YYYY-AA-GG)</string>
     <string name="store_button">Kaydet</string>
+    <string name="store_desc">Bu sayfada yeni bir kayıt oluşturur, dilerseniz erişim tarihini belirleyerek veriyi zaman kilitli hale getirirsiniz.</string>
+    <string name="hint_title">Başlık</string>
     <string name="retrieve_title">🔓 Geri Al</string>
+    <string name="retrieve_desc">Bu sayfada daha önce saklanan verileri kimlik ve parola ile geri alırsınız. Zaman kilidi belirlenmişse erişim günü gelmeden içerik gösterilmez.</string>
     <string name="hint_id">ID</string>
     <string name="hint_password">Parola</string>
     <string name="retrieve_button">Çöz</string>

--- a/android/app/src/main/res/values/strings.xml
+++ b/android/app/src/main/res/values/strings.xml
@@ -7,7 +7,10 @@
     <string name="hint_view">View password</string>
     <string name="hint_date">Unlock date (YYYY-MM-DD)</string>
     <string name="store_button">Store</string>
+    <string name="store_desc">On this page you create a new record; optionally specify an access date to time-lock the data.</string>
+    <string name="hint_title">Title</string>
     <string name="retrieve_title">🔓 Retrieve</string>
+    <string name="retrieve_desc">On this page you retrieve previously stored data with ID and password. If a time lock is set, the content is not shown before the access day.</string>
     <string name="hint_id">ID</string>
     <string name="hint_password">Password</string>
     <string name="retrieve_button">Retrieve</string>

--- a/android/app/src/main/res/values/strings.xml
+++ b/android/app/src/main/res/values/strings.xml
@@ -18,6 +18,9 @@
     <string name="why_trust_button">🛡️ Why Trust</string>
     <string name="home_button">Home</string>
     <string name="toggle_language">Switch Language</string>
+    <string name="home_store_desc">Encrypt your text or instructions and add a time lock. Until your set date arrives, access is impossible.</string>
+    <string name="home_retrieve_desc">Retrieve stored content with your ID and password. If a time lock is set, you must wait for its date.</string>
+    <string name="home_use_cases_desc">Explore scenarios such as will messages, emergency sharing, or preventing panic selling.</string>
     <string name="use_cases_title">Use Cases</string>
     <string name="use_cases_investment_title">Investment Discipline</string>
     <string name="use_cases_investment_desc">Lock your own instructions to the future to limit emotional decisions and prevent panic selling.</string>


### PR DESCRIPTION
## Summary
- Add title field and explanatory text to store page
- Show calendar picker for unlock date and permit cleartext dev traffic
- Tidy home buttons, update colors, and give retrieve page an orange gradient background

## Testing
- `bash gradlew test` *(fails: Unable to tunnel through proxy)*

------
https://chatgpt.com/codex/tasks/task_e_68a20cbe4b948331b07e93fb3b7b4811